### PR TITLE
Improve tests for node version utils

### DIFF
--- a/src/test/suite/node-version.test.ts
+++ b/src/test/suite/node-version.test.ts
@@ -1,0 +1,16 @@
+import * as assert from 'assert';
+import { parseWindowsNvmOutput, parseUnixNvmOutput } from '../../scripts/node-version';
+
+describe('Node Version Parsing', () => {
+    it('should parse versions from nvm-windows output', () => {
+        const output = `\n  * v20.5.1 (Currently using 64-bit executable)\n    v18.16.0\n    v16.14.0\n`;
+        const versions = parseWindowsNvmOutput(output);
+        assert.deepStrictEqual(versions, ['20.5.1', '18.16.0', '16.14.0']);
+    });
+
+    it('should parse versions from standard nvm output', () => {
+        const output = `\n       v18.12.1\n->     v20.2.0\n        system\ndefault -> v18.12.1\n`;
+        const versions = parseUnixNvmOutput(output);
+        assert.deepStrictEqual(versions, ['20.2.0', '18.12.1']);
+    });
+});


### PR DESCRIPTION
## Summary
- add parsing helpers for nvm outputs
- create tests covering node version parsing

## Testing
- `yarn test` *(fails: package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684acb2eb2cc832b929fa28ccbaacc92